### PR TITLE
Update usage of xml_find_one to xml_find_first

### DIFF
--- a/R/xslt.R
+++ b/R/xslt.R
@@ -72,7 +72,7 @@ xslt_transform <- function(xml_doc, xslt_doc,
 
   xslt_doc <- read_xslt(xslt_doc)
   ns <- xml_ns_rename(xml_ns(xslt_doc), xsl = "xsl")
-  out <- tryCatch(xml_attr(xml_find_one(xslt_doc, "xsl:output", ns), "method"),
+  out <- tryCatch(xml_attr(xml_find_first(xslt_doc, "xsl:output", ns), "method"),
                   error=function(err) { "xml" },
                   finally=function(err) { "xml" })
 


### PR DESCRIPTION
This function name was renamed in
https://github.com/hadley/xml2/commit/4039552674fcca2ab5c58c50a58a48c8ac64d546

Before this change, the user is warned when they transform a document:

> In addition: Warning message:
> 'xml_find_one' is deprecated.
> Use 'xml_find_first' instead.
> See help("Deprecated") 

After this change, the message goes away. I looked at the commit I linked above to see if anything other than the name changed and it appears it was just a name change. I've tested a document locally to make sure transforming still works with my change.
